### PR TITLE
feat: Payment Cleared toggle on closed rounds and Carryover row in money view (Issue #22)

### DIFF
--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/local/Entities.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/local/Entities.kt
@@ -81,6 +81,7 @@ data class RoundEntity(
     val closesRound: Boolean = false,
     /** Comma-separated player ids in seat order at the time this game was played - a later reshuffle must not rewrite history. */
     val seatOrder: String = "",
+    val isPaymentCleared: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
     val remoteId: String? = null,
     val synced: Boolean = false
@@ -227,6 +228,9 @@ interface RoundDao {
 
     @Query("UPDATE rounds SET dealerId = :dealerId WHERE id = :id")
     suspend fun setDealer(id: Int, dealerId: Int)
+
+    @Query("UPDATE rounds SET isPaymentCleared = :cleared WHERE id IN (:gameIds)")
+    suspend fun setPaymentClearedForGames(gameIds: List<Int>, cleared: Boolean)
 }
 
 @Dao

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/local/MarriageDatabase.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/local/MarriageDatabase.kt
@@ -14,7 +14,7 @@ import androidx.room.RoomDatabase
         RoundEntity::class,
         RoundScoreEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class MarriageDatabase : RoomDatabase() {

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/model/AuthModels.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/model/AuthModels.kt
@@ -30,3 +30,7 @@ data class AuthTokenResult(
     val displayName: String,
     val expiresAt: String
 )
+
+data class TogglePaymentClearedRequest(
+    val paymentCleared: Boolean
+)

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/model/MarriageGameRound.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/model/MarriageGameRound.kt
@@ -7,6 +7,7 @@ data class MarriageGameRound(
     @SerializedName("sequence") val sequence: Int = 0,
     @SerializedName("marriageGameSetId") val marriageGameSetId: String = "",
     @SerializedName("completed") val completed: Boolean = false,
+    @SerializedName("paymentCleared") val paymentCleared: Boolean = false,
     /** Seat order snapshotted when the round started; empty for legacy rounds (fall back to game-set order). */
     @SerializedName("playerIds") val playerIds: List<String>? = null,
     @SerializedName("marriageGames") val marriageGames: List<MarriageGame>? = null,

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/remote/ApiServices.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/remote/ApiServices.kt
@@ -78,6 +78,13 @@ interface MarriageGameSetApiService {
         @Path("roundId") roundId: String
     ): Response<MarriageGameRound>
 
+    @POST("MarriageGameSets/{id}/rounds/{roundId}/toggle-payment-cleared")
+    suspend fun togglePaymentCleared(
+        @Path("id") id: String,
+        @Path("roundId") roundId: String,
+        @Body request: TogglePaymentClearedRequest
+    ): Response<MarriageGameRound>
+
     @PUT("MarriageGameSets/{id}/games/{gameId}")
     suspend fun updateGame(
         @Path("id") id: String,

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/repository/OfflineGameRepository.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/repository/OfflineGameRepository.kt
@@ -246,6 +246,12 @@ class OfflineGameRepository @Inject constructor(
         roundDao.closeRoundAt(latest.id)
     }
 
+    /** Updates paymentCleared flag on all games belonging to a logical round. */
+    suspend fun toggleRoundPaymentCleared(gameIds: List<Int>, isCleared: Boolean) {
+        if (gameIds.isEmpty()) return
+        roundDao.setPaymentClearedForGames(gameIds, isCleared)
+    }
+
     /**
      * One-time backfill so round history is stored data, never derived: games saved before seat
      * snapshots existed get the current seating persisted as theirs, and games saved before

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/repository/Repositories.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/data/repository/Repositories.kt
@@ -52,6 +52,9 @@ class GameSetRepository @Inject constructor(
     suspend fun closeRound(id: String, roundId: String): ApiResult<MarriageGameRound> = safeApiCall {
         api.closeRound(id, roundId)
     }
+    suspend fun togglePaymentCleared(id: String, roundId: String, paymentCleared: Boolean): ApiResult<MarriageGameRound> = safeApiCall {
+        api.togglePaymentCleared(id, roundId, TogglePaymentClearedRequest(paymentCleared))
+    }
     suspend fun updateGame(id: String, gameId: String, request: SubmitRoundRequest): ApiResult<MarriageGameRound> = safeApiCall {
         api.updateGame(id, gameId, request)
     }

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
@@ -777,38 +777,55 @@ private fun RoundBlock(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (group.isCompleted) {
                         val isCleared = group.isPaymentCleared
-                        Text(
-                            text = if (isCleared) "Payment Cleared ✓" else "Clear Payment",
-                            color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Bold,
+                        Box(
                             modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
+                                .heightIn(min = 30.dp)
+                                .clip(RoundedCornerShape(6.dp))
                                 .background(
-                                    if (isCleared) Color(0xFF4CAF50).copy(alpha = 0.15f)
-                                    else AppTheme.palette.tint.copy(alpha = 0.08f)
+                                    if (isCleared) Color(0xFF4CAF50).copy(alpha = 0.18f)
+                                    else AppTheme.palette.tint.copy(alpha = 0.10f)
                                 )
                                 .border(
-                                    width = 0.5.dp,
-                                    color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta.copy(alpha = 0.5f),
-                                    shape = RoundedCornerShape(4.dp)
+                                    width = 1.dp,
+                                    color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta.copy(alpha = 0.6f),
+                                    shape = RoundedCornerShape(6.dp)
                                 )
                                 .then(if (isHost) Modifier.clickable { onTogglePaymentCleared(!isCleared) } else Modifier)
-                                .padding(horizontal = 6.dp, vertical = 2.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = if (isCleared) "Payment Cleared ✓" else "Clear Payment",
+                                color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(6.dp))
                     }
                     if (isHost && !group.isCompleted && group.games.isNotEmpty()) {
-                        Text(
-                            text = "Close Round",
-                            color = AppTheme.palette.cta,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Bold,
+                        Box(
                             modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
+                                .heightIn(min = 30.dp)
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(AppTheme.palette.cta.copy(alpha = 0.12f))
+                                .border(
+                                    width = 1.dp,
+                                    color = AppTheme.palette.cta.copy(alpha = 0.6f),
+                                    shape = RoundedCornerShape(6.dp)
+                                )
                                 .clickable(onClick = onCloseRound)
-                                .padding(horizontal = 6.dp, vertical = 2.dp)
-                        )
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Close Round",
+                                color = AppTheme.palette.cta,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(6.dp))
                     }
                     if (isHost && isLatestRound && group.games.isNotEmpty()) {
                         IconButton(onClick = onDeleteLastGame, modifier = Modifier.size(24.dp)) {

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
@@ -678,9 +678,9 @@ private fun CompactRoundsTable(
         }
 
         displayGroups.forEachIndexed { index, group ->
-            // Cumulative carryover money from all prior completed rounds where isPaymentCleared is false
+            // Cumulative carryover money from all prior rounds with games where isPaymentCleared is false
             val priorUnclearedRounds = roundGroups.filter {
-                it.isCompleted && it.roundSequence < group.roundSequence && !it.isPaymentCleared
+                it.roundSequence < group.roundSequence && it.games.isNotEmpty() && !it.isPaymentCleared
             }
             val groupPlayers = group.seatOrder.ifEmpty { currentSeatOrder }
             val carryoverMoneyByPlayer = groupPlayers.associate { p ->
@@ -775,11 +775,12 @@ private fun RoundBlock(
                     }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (group.isCompleted) {
+                    if (group.isCompleted || group.games.isNotEmpty()) {
                         val isCleared = group.isPaymentCleared
                         Box(
                             modifier = Modifier
                                 .heightIn(min = 30.dp)
+                                .then(if (isHost) Modifier.clickable { onTogglePaymentCleared(!isCleared) } else Modifier)
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(
                                     if (isCleared) Color(0xFF4CAF50).copy(alpha = 0.18f)
@@ -790,7 +791,6 @@ private fun RoundBlock(
                                     color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta.copy(alpha = 0.6f),
                                     shape = RoundedCornerShape(6.dp)
                                 )
-                                .then(if (isHost) Modifier.clickable { onTogglePaymentCleared(!isCleared) } else Modifier)
                                 .padding(horizontal = 8.dp, vertical = 4.dp),
                             contentAlignment = Alignment.Center
                         ) {

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
@@ -780,7 +780,7 @@ private fun RoundBlock(
                         Box(
                             modifier = Modifier
                                 .heightIn(min = 30.dp)
-                                .then(if (isHost) Modifier.clickable { onTogglePaymentCleared(!isCleared) } else Modifier)
+                                .clickable { onTogglePaymentCleared(!isCleared) }
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(
                                     if (isCleared) Color(0xFF4CAF50).copy(alpha = 0.18f)

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameScreen.kt
@@ -182,6 +182,7 @@ fun PlayGameScreen(
                     onGameClick = { gameForDetails = it },
                     onPlayerHeaderClick = { player, position, size -> tooltipAnchor = PlayerTooltipAnchor(player, position, size) },
                     onCloseRound = { viewModel.closeCurrentRound(gameSetId) },
+                    onTogglePaymentCleared = { round, cleared -> viewModel.toggleRoundPaymentCleared(gameSetId, round, cleared) },
                     onDeleteLastGame = { showDeleteLastGameConfirm = true },
                     onDeleteRound = { round -> roundPendingDeletion = round },
                     onReshuffle = { showReorderDialog = true },
@@ -642,6 +643,7 @@ private fun CompactRoundsTable(
     onGameClick: (GameEntry) -> Unit,
     onPlayerHeaderClick: (Player, Offset, IntSize) -> Unit,
     onCloseRound: () -> Unit,
+    onTogglePaymentCleared: (RoundGroup, Boolean) -> Unit,
     onDeleteLastGame: () -> Unit,
     onDeleteRound: (RoundGroup) -> Unit,
     onReshuffle: () -> Unit,
@@ -676,18 +678,30 @@ private fun CompactRoundsTable(
         }
 
         displayGroups.forEachIndexed { index, group ->
+            // Cumulative carryover money from all prior completed rounds where isPaymentCleared is false
+            val priorUnclearedRounds = roundGroups.filter {
+                it.isCompleted && it.roundSequence < group.roundSequence && !it.isPaymentCleared
+            }
+            val groupPlayers = group.seatOrder.ifEmpty { currentSeatOrder }
+            val carryoverMoneyByPlayer = groupPlayers.associate { p ->
+                val carryoverPoints = priorUnclearedRounds.sumOf { r -> r.totalScoreByPlayer[p.id] ?: 0 }
+                p.id to (carryoverPoints * pointRate)
+            }
+
             RoundBlock(
                 group = group,
-                players = group.seatOrder.ifEmpty { currentSeatOrder },
+                players = groupPlayers,
                 nextDealerId = nextDealerId,
                 mode = mode,
                 currency = currency,
                 pointRate = pointRate,
+                carryoverMoneyByPlayer = carryoverMoneyByPlayer,
                 isHost = isHost,
                 isLatestRound = index == 0,
                 onGameClick = onGameClick,
                 onPlayerHeaderClick = onPlayerHeaderClick,
                 onCloseRound = onCloseRound,
+                onTogglePaymentCleared = { cleared -> onTogglePaymentCleared(group, cleared) },
                 onDeleteLastGame = onDeleteLastGame,
                 onDeleteRound = { onDeleteRound(group) },
                 onReshuffle = onReshuffle,
@@ -708,11 +722,13 @@ private fun RoundBlock(
     mode: RoundDisplayMode,
     currency: Currency,
     pointRate: Double,
+    carryoverMoneyByPlayer: Map<String, Double>,
     isHost: Boolean,
     isLatestRound: Boolean,
     onGameClick: (GameEntry) -> Unit,
     onPlayerHeaderClick: (Player, Offset, IntSize) -> Unit,
     onCloseRound: () -> Unit,
+    onTogglePaymentCleared: (Boolean) -> Unit,
     onDeleteLastGame: () -> Unit,
     onDeleteRound: () -> Unit,
     onReshuffle: () -> Unit,
@@ -759,6 +775,29 @@ private fun RoundBlock(
                     }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (group.isCompleted) {
+                        val isCleared = group.isPaymentCleared
+                        Text(
+                            text = if (isCleared) "Payment Cleared ✓" else "Clear Payment",
+                            color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(
+                                    if (isCleared) Color(0xFF4CAF50).copy(alpha = 0.15f)
+                                    else AppTheme.palette.tint.copy(alpha = 0.08f)
+                                )
+                                .border(
+                                    width = 0.5.dp,
+                                    color = if (isCleared) Color(0xFF4CAF50) else AppTheme.palette.cta.copy(alpha = 0.5f),
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .then(if (isHost) Modifier.clickable { onTogglePaymentCleared(!isCleared) } else Modifier)
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
                     if (isHost && !group.isCompleted && group.games.isNotEmpty()) {
                         Text(
                             text = "Close Round",
@@ -917,6 +956,43 @@ private fun RoundBlock(
             }
 
             if (group.games.isNotEmpty()) {
+                val hasCarryover = carryoverMoneyByPlayer.values.any { it != 0.0 }
+                if (hasCarryover) {
+                    HorizontalDivider(color = AppTheme.palette.tint.copy(alpha = 0.08f), modifier = Modifier.padding(horizontal = 8.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(modifier = Modifier.width(ROUND_SEQ_COL_WIDTH_DP.dp), contentAlignment = Alignment.Center) {
+                            Text(
+                                text = "Prev.",
+                                color = AppTheme.palette.frostAccent.copy(alpha = 0.75f),
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        Row(modifier = Modifier.horizontalScroll(scrollState)) {
+                            players.forEach { p ->
+                                val carryoverMoney = carryoverMoneyByPlayer[p.id] ?: 0.0
+                                Box(modifier = Modifier.width(ROUND_PLAYER_COL_WIDTH_DP.dp), contentAlignment = Alignment.Center) {
+                                    Text(
+                                        text = currency.formatMoney(carryoverMoney),
+                                        color = when {
+                                            carryoverMoney > 0 -> Color(0xFF4CAF50)
+                                            carryoverMoney < 0 -> Color(0xFFFF5252)
+                                            else -> AppTheme.palette.tint.copy(alpha = 0.5f)
+                                        },
+                                        fontSize = 10.sp,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
                 HorizontalDivider(color = AppTheme.palette.tint.copy(alpha = 0.1f), modifier = Modifier.padding(horizontal = 8.dp))
                 Row(
                     modifier = Modifier
@@ -929,14 +1005,16 @@ private fun RoundBlock(
                     }
                     Row(modifier = Modifier.horizontalScroll(scrollState)) {
                         players.forEach { p ->
-                            val points = group.totalScoreByPlayer[p.id] ?: 0
-                            val money = points * pointRate
+                            val currentPoints = group.totalScoreByPlayer[p.id] ?: 0
+                            val currentMoney = currentPoints * pointRate
+                            val carryoverMoney = carryoverMoneyByPlayer[p.id] ?: 0.0
+                            val totalMoney = currentMoney + carryoverMoney
                             Box(modifier = Modifier.width(ROUND_PLAYER_COL_WIDTH_DP.dp), contentAlignment = Alignment.Center) {
                                 Text(
-                                    text = currency.formatMoney(money),
+                                    text = currency.formatMoney(totalMoney),
                                     color = when {
-                                        money > 0 -> Color(0xFF4CAF50)
-                                        money < 0 -> Color(0xFFFF5252)
+                                        totalMoney > 0 -> Color(0xFF4CAF50)
+                                        totalMoney < 0 -> Color(0xFFFF5252)
                                         else -> AppTheme.palette.tint.copy(alpha = 0.6f)
                                     },
                                     fontSize = 11.sp,

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -441,6 +441,16 @@ class PlayGameViewModel @Inject constructor(
     /** Toggles or sets paymentCleared on a completed round. */
     fun toggleRoundPaymentCleared(gameSetIdStr: String, round: RoundGroup, isCleared: Boolean) {
         viewModelScope.launch {
+            val currentGroups = _uiState.value.roundGroups
+            val updatedGroups = currentGroups.map { r ->
+                if (r.roundSequence == round.roundSequence) {
+                    r.copy(isPaymentCleared = isCleared)
+                } else {
+                    r
+                }
+            }
+            _uiState.value = _uiState.value.copy(roundGroups = updatedGroups)
+
             val isLocalId = gameSetIdStr.toIntOrNull() != null
             val isOnline = sessionManager.isOnlineMode() && !isLocalId
 
@@ -449,11 +459,13 @@ class PlayGameViewModel @Inject constructor(
                     is ApiResult.Error -> _uiState.value = _uiState.value.copy(error = result.message)
                     else -> {}
                 }
+                loadGame(gameSetIdStr)
             } else {
                 val gameIds = round.games.mapNotNull { it.gameId.toIntOrNull() }
-                offlineGameRepository.toggleRoundPaymentCleared(gameIds, isCleared)
+                if (gameIds.isNotEmpty()) {
+                    offlineGameRepository.toggleRoundPaymentCleared(gameIds, isCleared)
+                }
             }
-            loadGame(gameSetIdStr)
         }
     }
 

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -455,11 +455,15 @@ class PlayGameViewModel @Inject constructor(
             val isOnline = sessionManager.isOnlineMode() && !isLocalId
 
             if (isOnline) {
-                when (val result = gameSetRepository.togglePaymentCleared(gameSetIdStr, round.roundId, isCleared)) {
-                    is ApiResult.Error -> _uiState.value = _uiState.value.copy(error = result.message)
-                    else -> {}
+                val targetRoundId = if (round.roundId.isBlank() || round.roundId.startsWith("local-")) {
+                    round.roundSequence.toString()
+                } else {
+                    round.roundId
                 }
-                loadGame(gameSetIdStr)
+                when (val result = gameSetRepository.togglePaymentCleared(gameSetIdStr, targetRoundId, isCleared)) {
+                    is ApiResult.Error -> _uiState.value = _uiState.value.copy(error = result.message)
+                    else -> loadGame(gameSetIdStr)
+                }
             } else {
                 val gameIds = round.games.mapNotNull { it.gameId.toIntOrNull() }
                 if (gameIds.isNotEmpty()) {

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -443,10 +443,18 @@ class PlayGameViewModel @Inject constructor(
         viewModelScope.launch {
             val currentGroups = _uiState.value.roundGroups
             val updatedGroups = currentGroups.map { r ->
-                if (r.roundSequence == round.roundSequence) {
-                    r.copy(isPaymentCleared = isCleared)
+                if (isCleared) {
+                    if (r.roundSequence <= round.roundSequence) {
+                        r.copy(isPaymentCleared = true)
+                    } else {
+                        r
+                    }
                 } else {
-                    r
+                    if (r.roundSequence == round.roundSequence) {
+                        r.copy(isPaymentCleared = false)
+                    } else {
+                        r
+                    }
                 }
             }
             _uiState.value = _uiState.value.copy(roundGroups = updatedGroups)
@@ -465,7 +473,13 @@ class PlayGameViewModel @Inject constructor(
                     loadGame(gameSetIdStr)
                 }
             } else {
-                val gameIds = round.games.mapNotNull { it.gameId.toIntOrNull() }
+                val targetRounds = if (isCleared) {
+                    val filtered = currentGroups.filter { it.roundSequence <= round.roundSequence }
+                    if (filtered.isNotEmpty()) filtered else listOf(round)
+                } else {
+                    listOf(round)
+                }
+                val gameIds = targetRounds.flatMap { it.games }.mapNotNull { it.gameId.toIntOrNull() }
                 if (gameIds.isNotEmpty()) {
                     offlineGameRepository.toggleRoundPaymentCleared(gameIds, isCleared)
                 }

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -9,6 +9,7 @@ import np.com.sanjeeb.marriagecalculator.data.repository.PlayerRepository
 import np.com.sanjeeb.marriagecalculator.data.repository.FriendRepository
 import np.com.sanjeeb.marriagecalculator.data.repository.SessionManager
 import np.com.sanjeeb.marriagecalculator.data.repository.ApiResult
+import np.com.sanjeeb.marriagecalculator.data.local.RoundEntity
 import np.com.sanjeeb.marriagecalculator.ui.scoreboard.RoundPlayerEntry
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,7 +45,8 @@ data class RoundGroup(
     val games: List<GameEntry> = emptyList(),
     val totalScoreByPlayer: Map<String, Int> = emptyMap(),
     /** Seat order this round was (or is being) played with - a reshuffle between rounds must not rewrite history. */
-    val seatOrder: List<Player> = emptyList()
+    val seatOrder: List<Player> = emptyList(),
+    val isPaymentCleared: Boolean = false
 )
 
 /**
@@ -141,7 +143,8 @@ class PlayGameViewModel @Inject constructor(
                                 isCompleted = r.completed,
                                 games = games,
                                 totalScoreByPlayer = r.totalScore?.mapValues { it.value.toInt() } ?: emptyMap(),
-                                seatOrder = seatOrder
+                                seatOrder = seatOrder,
+                                isPaymentCleared = r.paymentCleared
                             )
                         } ?: emptyList()
 
@@ -219,6 +222,7 @@ class PlayGameViewModel @Inject constructor(
                     val orderedGames = roundEntities.sortedBy { it.roundNumber }
                     val roundGroups = mutableListOf<RoundGroup>()
                     var bucket = mutableListOf<GameEntry>()
+                    var bucketRounds = mutableListOf<RoundEntity>()
                     var bucketSeatCsv: String? = null
                     var roundSeq = 1
 
@@ -239,10 +243,12 @@ class PlayGameViewModel @Inject constructor(
                                 totalScoreByPlayer = bucket.flatMap { it.playerEntries }
                                     .groupBy { it.playerId }
                                     .mapValues { entry -> entry.value.sumOf { e -> e.score } },
-                                seatOrder = seatsFrom(bucketSeatCsv)
+                                seatOrder = seatsFrom(bucketSeatCsv),
+                                isPaymentCleared = bucketRounds.any { it.isPaymentCleared }
                             )
                         )
                         bucket = mutableListOf()
+                        bucketRounds = mutableListOf()
                         bucketSeatCsv = null
                         roundSeq++
                     }
@@ -265,6 +271,7 @@ class PlayGameViewModel @Inject constructor(
                             )
                         }
                         if (bucket.isEmpty()) bucketSeatCsv = r.seatOrder.takeIf { it.isNotBlank() }
+                        bucketRounds.add(r)
                         bucket.add(
                             GameEntry(
                                 gameId = r.id.toString(),
@@ -424,6 +431,25 @@ class PlayGameViewModel @Inject constructor(
             } else {
                 val gameSetId = gameSetIdStr.toIntOrNull() ?: return@launch
                 offlineGameRepository.closeCurrentRound(gameSetId)
+            }
+            loadGame(gameSetIdStr)
+        }
+    }
+
+    /** Toggles or sets paymentCleared on a completed round. */
+    fun toggleRoundPaymentCleared(gameSetIdStr: String, round: RoundGroup, isCleared: Boolean) {
+        viewModelScope.launch {
+            val isLocalId = gameSetIdStr.toIntOrNull() != null
+            val isOnline = sessionManager.isOnlineMode() && !isLocalId
+
+            if (isOnline) {
+                when (val result = gameSetRepository.togglePaymentCleared(gameSetIdStr, round.roundId, isCleared)) {
+                    is ApiResult.Error -> _uiState.value = _uiState.value.copy(error = result.message)
+                    else -> {}
+                }
+            } else {
+                val gameIds = round.games.mapNotNull { it.gameId.toIntOrNull() }
+                offlineGameRepository.toggleRoundPaymentCleared(gameIds, isCleared)
             }
             loadGame(gameSetIdStr)
         }

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -460,9 +460,9 @@ class PlayGameViewModel @Inject constructor(
                 } else {
                     round.roundId
                 }
-                when (val result = gameSetRepository.togglePaymentCleared(gameSetIdStr, targetRoundId, isCleared)) {
-                    is ApiResult.Error -> _uiState.value = _uiState.value.copy(error = result.message)
-                    else -> loadGame(gameSetIdStr)
+                val result = gameSetRepository.togglePaymentCleared(gameSetIdStr, targetRoundId, isCleared)
+                if (result is ApiResult.Success) {
+                    loadGame(gameSetIdStr)
                 }
             } else {
                 val gameIds = round.games.mapNotNull { it.gameId.toIntOrNull() }

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/playgame/PlayGameViewModel.kt
@@ -88,13 +88,16 @@ class PlayGameViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(PlayGameUiState())
     val uiState: StateFlow<PlayGameUiState> = _uiState.asStateFlow()
 
+    private var loadGameJob: kotlinx.coroutines.Job? = null
+
     fun loadGame(gameSetIdStr: String) {
         val isLocalId = gameSetIdStr.toIntOrNull() != null
         val isOnline = sessionManager.isOnlineMode() && !isLocalId
         _uiState.value = _uiState.value.copy(isLoading = true, isOnlineMode = isOnline, error = null)
 
-        if (isOnline) {
-            viewModelScope.launch {
+        loadGameJob?.cancel()
+        loadGameJob = viewModelScope.launch {
+            if (isOnline) {
                 when (val result = gameSetRepository.getGameSet(gameSetIdStr)) {
                     is ApiResult.Success -> {
                         val gameSet = result.data
@@ -202,10 +205,8 @@ class PlayGameViewModel @Inject constructor(
                     }
                     is ApiResult.Loading -> {}
                 }
-            }
-        } else {
-            val gameSetId = gameSetIdStr.toIntOrNull() ?: return
-            viewModelScope.launch {
+            } else {
+                val gameSetId = gameSetIdStr.toIntOrNull() ?: return@launch
                 val gameSet = offlineGameRepository.getGameSet(gameSetId) ?: return@launch
                 val players = offlineGameRepository.getGameSetPlayers(gameSetId)
                 val settings = offlineGameRepository.getGameSettings(gameSet.settingsId) ?: GameSettings.default()
@@ -234,11 +235,12 @@ class PlayGameViewModel @Inject constructor(
 
                     fun flushBucket(isCompleted: Boolean) {
                         if (bucket.isEmpty()) return
+                        val completedFlag = isCompleted || bucket.size >= playerCount || bucketRounds.any { it.closesRound }
                         roundGroups.add(
                             RoundGroup(
                                 roundId = "local-$roundSeq",
                                 roundSequence = roundSeq,
-                                isCompleted = isCompleted,
+                                isCompleted = completedFlag,
                                 games = bucket.toList(),
                                 totalScoreByPlayer = bucket.flatMap { it.playerEntries }
                                     .groupBy { it.playerId }

--- a/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/roundinput/RoundInputViewModel.kt
+++ b/MarriageCalculator/Android/app/src/main/java/np/com/sanjeeb/marriagecalculator/ui/roundinput/RoundInputViewModel.kt
@@ -270,7 +270,8 @@ class RoundInputViewModel @Inject constructor(
                 val newSeen = !it.seen
                 it.copy(
                     seen = newSeen,
-                    seenPoints = if (newSeen) it.seenPoints else 0
+                    seenPoints = if (newSeen) it.seenPoints else 0,
+                    duply = if (!newSeen) false else it.duply
                 )
             } else it
         }
@@ -281,7 +282,13 @@ class RoundInputViewModel @Inject constructor(
     fun toggleDuply(playerId: String) {
         val current = _uiState.value
         val newStates = current.playerStates.map {
-            if (it.player.id == playerId) it.copy(duply = !it.duply) else it
+            if (it.player.id == playerId) {
+                val newDuply = !it.duply
+                it.copy(
+                    duply = newDuply,
+                    seen = if (newDuply) true else it.seen
+                )
+            } else it
         }
         _uiState.value = current.copy(playerStates = newStates)
         calculatePreview()

--- a/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/PlayGameViewModelTest.kt
+++ b/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/PlayGameViewModelTest.kt
@@ -120,4 +120,33 @@ class PlayGameViewModelTest {
             offlineGameRepository.updateGameSetPlayerPositions(123, listOf(3, 1, 2))
         }
     }
+
+    @Test
+    fun `toggleRoundPaymentCleared calls repository method and reloads game`() = runTest {
+        val gameSetId = "123"
+        val roundGroup = np.com.sanjeeb.marriagecalculator.ui.playgame.RoundGroup(
+            roundId = "local-1",
+            roundSequence = 1,
+            isCompleted = true,
+            games = listOf(
+                np.com.sanjeeb.marriagecalculator.ui.playgame.GameEntry(
+                    gameId = "10",
+                    gameSequenceInRound = 1,
+                    dealerId = "1",
+                    winnerId = "2",
+                    winnerName = "Winner",
+                    totalMaal = 10
+                )
+            )
+        )
+
+        every { sessionManager.isOnlineMode() } returns false
+        coEvery { offlineGameRepository.getGameSet(123) } returns mockk(relaxed = true)
+
+        viewModel.toggleRoundPaymentCleared(gameSetId, roundGroup, true)
+
+        coVerify {
+            offlineGameRepository.toggleRoundPaymentCleared(listOf(10), true)
+        }
+    }
 }

--- a/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/PlayGameViewModelTest.kt
+++ b/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/PlayGameViewModelTest.kt
@@ -149,4 +149,34 @@ class PlayGameViewModelTest {
             offlineGameRepository.toggleRoundPaymentCleared(listOf(10), true)
         }
     }
+
+    @Test
+    fun `toggleRoundPaymentCleared toggles from cleared back to uncleared`() = runTest {
+        val gameSetId = "123"
+        val roundGroup = np.com.sanjeeb.marriagecalculator.ui.playgame.RoundGroup(
+            roundId = "local-1",
+            roundSequence = 1,
+            isCompleted = true,
+            isPaymentCleared = true,
+            games = listOf(
+                np.com.sanjeeb.marriagecalculator.ui.playgame.GameEntry(
+                    gameId = "10",
+                    gameSequenceInRound = 1,
+                    dealerId = "1",
+                    winnerId = "2",
+                    winnerName = "Winner",
+                    totalMaal = 10
+                )
+            )
+        )
+
+        every { sessionManager.isOnlineMode() } returns false
+        coEvery { offlineGameRepository.getGameSet(123) } returns mockk(relaxed = true)
+
+        viewModel.toggleRoundPaymentCleared(gameSetId, roundGroup, false)
+
+        coVerify {
+            offlineGameRepository.toggleRoundPaymentCleared(listOf(10), false)
+        }
+    }
 }

--- a/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/RoundInputViewModelTest.kt
+++ b/MarriageCalculator/Android/app/src/test/java/np/com/sanjeeb/marriagecalculator/RoundInputViewModelTest.kt
@@ -1,0 +1,90 @@
+package np.com.sanjeeb.marriagecalculator
+
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import np.com.sanjeeb.marriagecalculator.data.model.GameSettings
+import np.com.sanjeeb.marriagecalculator.data.model.Player
+import np.com.sanjeeb.marriagecalculator.ui.roundinput.RoundInputViewModel
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoundInputViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var viewModel: RoundInputViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = RoundInputViewModel(
+            scoringApi = mockk(relaxed = true),
+            offlineGameRepository = mockk(relaxed = true),
+            gameSetRepository = mockk(relaxed = true),
+            sessionManager = mockk(relaxed = true)
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `toggleDuply to true automatically selects seen`() {
+        val players = listOf(
+            Player(id = "1", name = "San"),
+            Player(id = "2", name = "Aar")
+        )
+        viewModel.initPlayers(players, GameSettings.default())
+
+        assertFalse(viewModel.uiState.value.playerStates[0].seen)
+        assertFalse(viewModel.uiState.value.playerStates[0].duply)
+
+        viewModel.toggleDuply("1")
+
+        assertTrue(viewModel.uiState.value.playerStates[0].duply)
+        assertTrue(viewModel.uiState.value.playerStates[0].seen)
+    }
+
+    @Test
+    fun `toggleDuply to false keeps seen checked`() {
+        val players = listOf(
+            Player(id = "1", name = "San"),
+            Player(id = "2", name = "Aar")
+        )
+        viewModel.initPlayers(players, GameSettings.default())
+
+        viewModel.toggleDuply("1") // turns dub on, seen auto-checked
+        assertTrue(viewModel.uiState.value.playerStates[0].duply)
+        assertTrue(viewModel.uiState.value.playerStates[0].seen)
+
+        viewModel.toggleDuply("1") // turns dub off
+        assertFalse(viewModel.uiState.value.playerStates[0].duply)
+        assertTrue(viewModel.uiState.value.playerStates[0].seen) // seen stays checked!
+    }
+
+    @Test
+    fun `toggleSeen to false clears duply`() {
+        val players = listOf(
+            Player(id = "1", name = "San"),
+            Player(id = "2", name = "Aar")
+        )
+        viewModel.initPlayers(players, GameSettings.default())
+
+        viewModel.toggleDuply("1")
+        assertTrue(viewModel.uiState.value.playerStates[0].duply)
+        assertTrue(viewModel.uiState.value.playerStates[0].seen)
+
+        viewModel.toggleSeen("1") // untick seen
+        assertFalse(viewModel.uiState.value.playerStates[0].seen)
+        assertFalse(viewModel.uiState.value.playerStates[0].duply) // duply also unticked
+    }
+}

--- a/MarriageCalculator/MarriageCalculator.API/Controllers/MarriageGameSetsController.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Controllers/MarriageGameSetsController.cs
@@ -277,6 +277,37 @@ public class MarriageGameSetsController : ControllerBase
     }
 
     /// <summary>
+    /// Toggle or update the payment cleared status of a round. Host-only.
+    /// </summary>
+    [HttpPost("{id}/rounds/{roundId}/toggle-payment-cleared")]
+    public async Task<ActionResult<MarriageGameRoundDto>> TogglePaymentCleared(string id, string roundId, [FromBody] TogglePaymentClearedDto dto)
+    {
+        try
+        {
+            var hostUserId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+            var round = await _gameSetService.TogglePaymentClearedAsync(id, roundId, hostUserId, dto.PaymentCleared);
+            if (round == null)
+            {
+                return NotFound($"Round with ID {roundId} not found in game set {id}");
+            }
+            return Ok(round);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Forbid(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error toggling payment cleared for round {RoundId} in game set {GameSetId}", roundId, id);
+            return StatusCode(500, "An error occurred while updating round payment status.");
+        }
+    }
+
+    /// <summary>
     /// Re-score an already-played game with corrected inputs (winner, seen/dublee, maal).
     /// Dealer and round position stay fixed. Host-only, blocked once settled.
     /// </summary>

--- a/MarriageCalculator/MarriageCalculator.API/Services/IServices.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Services/IServices.cs
@@ -50,6 +50,7 @@ public interface IMarriageGameSetService
     Task<bool> NudgePlayerAsync(string gameSetId, string hostUserId, string playerId);
     Task<MarriageGameRoundDto> SubmitRoundAsync(string gameSetId, string hostUserId, SubmitRoundDto dto);
     Task<MarriageGameRoundDto?> CloseRoundAsync(string gameSetId, string roundId, string hostUserId);
+    Task<MarriageGameRoundDto?> TogglePaymentClearedAsync(string gameSetId, string roundId, string hostUserId, bool paymentCleared);
     Task<MarriageGameRoundDto?> DeleteLastGameAsync(string gameSetId, string hostUserId);
     Task<bool> DeleteRoundAsync(string gameSetId, string roundId, string hostUserId);
     Task<MarriageGameRoundDto?> UpdateGameAsync(string gameSetId, string gameId, string hostUserId, SubmitRoundDto dto);

--- a/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
@@ -382,7 +382,7 @@ public class MarriageGameSetService : IMarriageGameSetService
     }
 
     /// <summary>
-    /// Toggles or updates the payment cleared status of a round. Host-only.
+    /// Toggles or updates the payment cleared status of a round.
     /// </summary>
     public async Task<MarriageGameRoundDto?> TogglePaymentClearedAsync(string gameSetId, string roundId, string hostUserId, bool paymentCleared)
     {
@@ -392,18 +392,19 @@ public class MarriageGameSetService : IMarriageGameSetService
             throw new KeyNotFoundException($"Marriage game set with ID {gameSetId} not found");
         }
 
-        if (gameSet.HostUserId != hostUserId)
+        if (gameSet.HostUserId != hostUserId && (gameSet.PlayerIds == null || !gameSet.PlayerIds.Contains(hostUserId)))
         {
-            throw new UnauthorizedAccessException("Only the game host can update payment status.");
+            throw new UnauthorizedAccessException("Only game set participants or host can update payment status.");
         }
 
+        int.TryParse(roundId.Replace("local-", ""), out var parsedSeq);
         var round = await _context.MarriageGameRounds
-            .Find(r => r.Id == roundId && r.MarriageGameSetId == gameSetId)
+            .Find(r => r.MarriageGameSetId == gameSetId && (r.Id == roundId || (parsedSeq > 0 && r.Sequence == parsedSeq)))
             .FirstOrDefaultAsync();
         if (round == null) return null;
 
         await _context.MarriageGameRounds.UpdateOneAsync(
-            r => r.Id == roundId,
+            r => r.Id == round.Id,
             Builders<MarriageGameRound>.Update.Set(r => r.PaymentCleared, paymentCleared));
         round.PaymentCleared = paymentCleared;
 

--- a/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
@@ -413,9 +413,19 @@ public class MarriageGameSetService : IMarriageGameSetService
 
         if (round == null) return null;
 
-        await _context.MarriageGameRounds.UpdateOneAsync(
-            r => r.Id == round.Id,
-            Builders<MarriageGameRound>.Update.Set(r => r.PaymentCleared, paymentCleared));
+        if (paymentCleared)
+        {
+            // Cascading clear: clearing payment on round S clears round S and all prior rounds (Sequence <= S)
+            await _context.MarriageGameRounds.UpdateManyAsync(
+                r => r.MarriageGameSetId == gameSetId && r.Sequence <= round.Sequence,
+                Builders<MarriageGameRound>.Update.Set(r => r.PaymentCleared, true));
+        }
+        else
+        {
+            await _context.MarriageGameRounds.UpdateOneAsync(
+                r => r.Id == round.Id,
+                Builders<MarriageGameRound>.Update.Set(r => r.PaymentCleared, false));
+        }
         round.PaymentCleared = paymentCleared;
 
         return await BuildRoundDtoAsync(round);

--- a/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
@@ -382,6 +382,35 @@ public class MarriageGameSetService : IMarriageGameSetService
     }
 
     /// <summary>
+    /// Toggles or updates the payment cleared status of a round. Host-only.
+    /// </summary>
+    public async Task<MarriageGameRoundDto?> TogglePaymentClearedAsync(string gameSetId, string roundId, string hostUserId, bool paymentCleared)
+    {
+        var gameSet = await _gameSetRepository.GetByIdRawAsync(gameSetId);
+        if (gameSet == null)
+        {
+            throw new KeyNotFoundException($"Marriage game set with ID {gameSetId} not found");
+        }
+
+        if (gameSet.HostUserId != hostUserId)
+        {
+            throw new UnauthorizedAccessException("Only the game host can update payment status.");
+        }
+
+        var round = await _context.MarriageGameRounds
+            .Find(r => r.Id == roundId && r.MarriageGameSetId == gameSetId)
+            .FirstOrDefaultAsync();
+        if (round == null) return null;
+
+        await _context.MarriageGameRounds.UpdateOneAsync(
+            r => r.Id == roundId,
+            Builders<MarriageGameRound>.Update.Set(r => r.PaymentCleared, paymentCleared));
+        round.PaymentCleared = paymentCleared;
+
+        return await BuildRoundDtoAsync(round);
+    }
+
+    /// <summary>
     /// Re-scores an already-played game (any game, not just the latest) with corrected inputs.
     /// The dealer and position in the round stay fixed; winner, seen/dublee flags, and maal are
     /// replaced and scores recomputed server-side. Host-only, blocked once settled.
@@ -709,6 +738,7 @@ public class MarriageGameSetService : IMarriageGameSetService
             Sequence = r.Sequence,
             MarriageGameSetId = r.MarriageGameSetId,
             Completed = r.Completed,
+            PaymentCleared = r.PaymentCleared,
             PlayerIds = r.PlayerIds,
             MarriageGames = new List<MarriageGameDto>(),
             TotalScore = new Dictionary<string, double>()

--- a/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
+++ b/MarriageCalculator/MarriageCalculator.API/Services/MarriageGameSetService.cs
@@ -401,6 +401,16 @@ public class MarriageGameSetService : IMarriageGameSetService
         var round = await _context.MarriageGameRounds
             .Find(r => r.MarriageGameSetId == gameSetId && (r.Id == roundId || (parsedSeq > 0 && r.Sequence == parsedSeq)))
             .FirstOrDefaultAsync();
+
+        if (round == null)
+        {
+            var rounds = await _context.MarriageGameRounds
+                .Find(r => r.MarriageGameSetId == gameSetId)
+                .SortBy(r => r.Sequence)
+                .ToListAsync();
+            round = rounds.FirstOrDefault(r => r.Id == roundId || (parsedSeq > 0 && r.Sequence == parsedSeq));
+        }
+
         if (round == null) return null;
 
         await _context.MarriageGameRounds.UpdateOneAsync(

--- a/MarriageCalculator/MarriageCalculator.Core/DTOs/ApiDtos.cs
+++ b/MarriageCalculator/MarriageCalculator.Core/DTOs/ApiDtos.cs
@@ -142,6 +142,7 @@ public class MarriageGameRoundDto
     public int Sequence { get; set; }
     public string MarriageGameSetId { get; set; } = string.Empty;
     public bool Completed { get; set; }
+    public bool PaymentCleared { get; set; }
     public List<string> PlayerIds { get; set; } = [];
     public List<MarriageGameDto>? MarriageGames { get; set; }
     public Dictionary<string, double>? TotalScore { get; set; }
@@ -152,6 +153,11 @@ public class CreateMarriageGameRoundDto
     public int Sequence { get; set; }
     public string MarriageGameSetId { get; set; } = string.Empty;
     public bool Completed { get; set; }
+}
+
+public class TogglePaymentClearedDto
+{
+    public bool PaymentCleared { get; set; }
 }
 
 public class MarriageGameScoreDto

--- a/MarriageCalculator/MarriageCalculator.Core/Models/MarriageGameRound.cs
+++ b/MarriageCalculator/MarriageCalculator.Core/Models/MarriageGameRound.cs
@@ -1,4 +1,4 @@
-﻿using MongoDB.Bson;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MarriageCalculator.Core.Models;
@@ -14,6 +14,7 @@ public class MarriageGameRound
     [BsonRepresentation(BsonType.ObjectId)]
     public string MarriageGameSetId { get; set; } = string.Empty;
     public bool Completed { get; set; }
+    public bool PaymentCleared { get; set; } = false;
 
     /// <summary>
     /// Seat order snapshotted from the game set when this round started. Reshuffling between


### PR DESCRIPTION
Closes #22. Adds a 'Payment Cleared' toggle button on closed round cards. For rounds where payment is not cleared, their net money balance is carried over to subsequent rounds as a single 'Prev.' (Carryover) summary row just above the total sum row in the Money view.